### PR TITLE
Added ability to view CSV of pull request history

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "body-parser": "^1.15.2",
     "cookie-session": "^2.0.0-alpha.2",
     "dotenv": "^2.0.0",
+    "express-csv": "^0.6.0",
     "font-awesome": "^4.7.0",
     "github": "^7.1.0",
     "knex": "^0.12.6",

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -79,6 +79,14 @@ router.post('/pull-request-review-requests/:prrrId/complete', (req, res, next) =
     .catch(next)
 });
 
+router.get('/statistics/csv', (req, res) => {
+  Promise.all([
+    req.queries.getPrrrColumns(),
+    req.queries.getAllPrrrs()
+  ])
+  .then(([ columns, result ]) => res.csv([ Object.keys(columns), ...result ]))
+});
+
 // error handlers
 
 router.use((req, res, next) => {

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,7 @@ import path from 'path'
 import express from 'express'
 import logger from 'morgan'
 import bodyParser from 'body-parser'
+import csv from 'express-csv'
 import passport from 'passport'
 import cookieSession from 'cookie-session'
 

--- a/server/queries/index.js
+++ b/server/queries/index.js
@@ -27,14 +27,22 @@ export default class Queries {
   }
 
   getPrrrs(){
-    return this.knex
-      .select('*')
-      .from('pull_request_review_requests')
-      .orderBy('created_at', 'desc')
+    return this.getAllPrrrs()
       .where({
         archived_at: null,
         completed_at: null,
       })
+  }
+
+  getAllPrrrs() {
+    return this.knex
+      .select('*')
+      .from('pull_request_review_requests')
+      .orderBy('created_at', 'desc')
+  }
+
+  getPrrrColumns() {
+    return this.knex('pull_request_review_requests').columnInfo()
   }
 
   getPrrrById(prrrId){


### PR DESCRIPTION
* `getAllPrrs` added to queries - fetches all records in table `pull_request_review_requests`
* `getPrrColumns` added to queries - fetches columns names in table `pull_request_review_requests`
* `getPrrs` updated to de-dupe logic now used in getAllPrrs
* added route GET /statistics/csv - returns a CSV file listing all records in table `pull_request_review_requests`
* added dependency for CSV formatting/response - `express-csv`